### PR TITLE
Improve accessibility for login and clients pages

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -11,12 +11,12 @@
   --ss-primary: #1e40af;
   --ss-primary-light: #3b82f6;
   --ss-primary-dark: #1e3a8a;
-  --ss-secondary: #059669;
-  --ss-secondary-light: #10b981;
-  --ss-accent: #f59e0b;
+  --ss-secondary: #047857;
+  --ss-secondary-light: #0c9a6d;
+  --ss-accent: #b65a00;
   --ss-danger: #dc2626;
-  --ss-success: #059669;
-  --ss-warning: #f59e0b;
+  --ss-success: #047857;
+  --ss-warning: #b65a00;
   --ss-info: #0ea5e9;
 
   /* Neutral Colors */
@@ -34,8 +34,8 @@
 
   /* Gradients */
   --ss-gradient-primary: linear-gradient(135deg, #3b82f6 0%, #1e40af 100%);
-  --ss-gradient-secondary: linear-gradient(135deg, #10b981 0%, #059669 100%);
-  --ss-gradient-accent: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
+  --ss-gradient-secondary: linear-gradient(135deg, #0c9a6d 0%, #047857 100%);
+  --ss-gradient-accent: linear-gradient(135deg, #e0ac00 0%, #b65a00 100%);
   --ss-gradient-bg: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
 
   /* Shadows */
@@ -71,6 +71,18 @@ body {
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* ===== SIDEBAR NAVIGATION ===== */
@@ -447,6 +459,18 @@ body {
   border-color: var(--ss-primary);
   box-shadow: 0 0 0 3px rgba(30, 64, 175, 0.1);
   transform: translateY(-1px);
+}
+
+.validation-message {
+  font-size: 0.875rem;
+}
+
+.validation-message.success {
+  color: var(--ss-success);
+}
+
+.validation-message.error {
+  color: var(--ss-danger);
 }
 
 .ss-form-control::placeholder {

--- a/public/html/clientes.html
+++ b/public/html/clientes.html
@@ -9,12 +9,12 @@
   <body>
     <!-- Sidebar -->
     <nav class="ss-sidebar" id="sidebar">
-      <button class="ss-sidebar-toggle" onclick="toggleSidebar()">
+      <button class="ss-sidebar-toggle" onclick="toggleSidebar()" aria-label="Alternar menú de navegación">
         <i class="bi bi-list"></i>
       </button>
 
       <div class="ss-sidebar-header">
-        <img src="../images/logo.png" alt="Logo" class="ss-sidebar-logo" />
+        <img src="../images/logo.png" alt="Logotipo de Seguros Sayazu" class="ss-sidebar-logo" />
         <h3 class="ss-sidebar-brand">Seguros Sayazu</h3>
       </div>
 
@@ -61,7 +61,7 @@
     <!-- Main Content -->
     <main class="ss-main-content" id="mainContent">
       <!-- Header -->
-      <div class="ss-header">
+      <header class="ss-header">
         <div>
           <h1 class="ss-header-title">Gestión de Clientes</h1>
           <p class="ss-header-subtitle">
@@ -79,7 +79,7 @@
             </div>
           </div>
         </div>
-      </div>
+      </header>
 
       <!-- Stats Cards -->
       <div class="ss-stats-grid">
@@ -158,7 +158,7 @@
             <div class="row g-3">
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Documento de Identidad</label>
+                  <label for="documentoidentidad" class="ss-form-label">Documento de Identidad</label>
                   <div class="ss-input-group">
                     <i class="bi bi-card-text ss-input-icon"></i>
                     <input
@@ -171,14 +171,14 @@
                   </div>
                   <span
                     id="documentoidentidad-validation"
-                    class="text-danger small"
+                    class="validation-message"
                   ></span>
                 </div>
               </div>
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Nombre Completo</label>
+                  <label for="nombrecompleto" class="ss-form-label">Nombre Completo</label>
                   <div class="ss-input-group">
                     <i class="bi bi-person ss-input-icon"></i>
                     <input
@@ -194,7 +194,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Correo Electrónico</label>
+                  <label for="correo" class="ss-form-label">Correo Electrónico</label>
                   <div class="ss-input-group">
                     <i class="bi bi-envelope ss-input-icon"></i>
                     <input
@@ -205,13 +205,13 @@
                       required
                     />
                   </div>
-                  <span id="correo-validation" class="text-danger small"></span>
+                  <span id="correo-validation" class="validation-message"></span>
                 </div>
               </div>
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Tipo de Cliente</label>
+                  <label for="tipocliente" class="ss-form-label">Tipo de Cliente</label>
                   <select id="tipocliente" class="ss-form-control" required>
                     <option value="">Seleccione el tipo</option>
                     <option value="Natural">Natural</option>
@@ -222,7 +222,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Ciudad</label>
+                  <label for="ciudad" class="ss-form-label">Ciudad</label>
                   <div class="ss-input-group">
                     <i class="bi bi-geo-alt ss-input-icon"></i>
                     <input
@@ -238,7 +238,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Dirección</label>
+                  <label for="direccion" class="ss-form-label">Dirección</label>
                   <div class="ss-input-group">
                     <i class="bi bi-house ss-input-icon"></i>
                     <input
@@ -254,7 +254,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Teléfono</label>
+                  <label for="telefonoaseguradora" class="ss-form-label">Teléfono</label>
                   <div class="ss-input-group">
                     <i class="bi bi-telephone ss-input-icon"></i>
                     <input
@@ -270,7 +270,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Compañía Aseguradora</label>
+                  <label for="company-register" class="ss-form-label">Compañía Aseguradora</label>
                   <select
                     id="company-register"
                     class="ss-form-control"
@@ -295,7 +295,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Tipo de Seguro</label>
+                  <label for="insuranceType-register" class="ss-form-label">Tipo de Seguro</label>
                   <select
                     id="insuranceType-register"
                     class="ss-form-control"
@@ -309,7 +309,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Producto</label>
+                  <label for="product-register" class="ss-form-label">Producto</label>
                   <select id="product-register" class="ss-form-control">
                     <option value="">Seleccione el producto</option>
                   </select>
@@ -318,7 +318,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Póliza</label>
+                  <label for="poliza" class="ss-form-label">Póliza</label>
                   <div class="ss-input-group">
                     <i class="bi bi-file-text ss-input-icon"></i>
                     <input
@@ -333,7 +333,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Deducible</label>
+                  <label for="deducible" class="ss-form-label">Deducible</label>
                   <div class="ss-input-group">
                     <i class="bi bi-currency-dollar ss-input-icon"></i>
                     <input
@@ -348,7 +348,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Fecha de Inicio</label>
+                  <label for="fechainicio" class="ss-form-label">Fecha de Inicio</label>
                   <input
                     type="date"
                     id="fechainicio"
@@ -360,8 +360,8 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label"
-                    >Fecha de Inicio de Vigencia</label
+                  <label for="fechainiciovigencia" class="ss-form-label">
+                    Fecha de Inicio de Vigencia</label
                   >
                   <input
                     type="date"
@@ -373,7 +373,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Fecha de Vencimiento</label>
+                  <label for="fechavencimientopoliza" class="ss-form-label">Fecha de Vencimiento</label>
                   <input
                     type="date"
                     id="fechavencimientopoliza"
@@ -384,7 +384,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Tipo</label>
+                  <label for="tipo" class="ss-form-label">Tipo</label>
                   <select id="tipo" class="ss-form-control" required>
                     <option value="">Seleccione el tipo</option>
                     <option value="Individual">Individual</option>
@@ -395,7 +395,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Estado</label>
+                  <label for="status" class="ss-form-label">Estado</label>
                   <select id="status" class="ss-form-control" required>
                     <option value="">Seleccione el estado</option>
                     <option value="Activo">Activo</option>
@@ -406,7 +406,7 @@
 
               <div class="col-md-6">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Causa de Cancelación</label>
+                  <label for="causacancelacion" class="ss-form-label">Causa de Cancelación</label>
                   <textarea
                     id="causacancelacion"
                     class="ss-form-control"
@@ -418,7 +418,7 @@
 
               <div class="col-md-6">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Observaciones</label>
+                  <label for="observaciones" class="ss-form-label">Observaciones</label>
                   <textarea
                     id="observaciones"
                     class="ss-form-control"
@@ -430,7 +430,7 @@
 
               <div class="col-md-4">
                 <div class="ss-form-group">
-                  <label class="ss-form-label">Fecha de Cancelación</label>
+                  <label for="fechacancelacion" class="ss-form-label">Fecha de Cancelación</label>
                   <input
                     type="date"
                     id="fechacancelacion"
@@ -479,7 +479,7 @@
           <div class="row g-3">
             <div class="col-md-6">
               <div class="ss-form-group">
-                <label class="ss-form-label">Documento de Identidad</label>
+                <label for="documentoidentidad-consulta" class="ss-form-label">Documento de Identidad</label>
                 <div class="ss-input-group">
                   <i class="bi bi-card-text ss-input-icon"></i>
                   <input
@@ -612,7 +612,7 @@
           <div class="row g-3">
             <div class="col-md-6">
               <div class="ss-form-group">
-                <label class="ss-form-label">Documento de Identidad</label>
+                <label for="documentoidentidad-update" class="ss-form-label">Documento de Identidad</label>
                 <div class="ss-input-group">
                   <i class="bi bi-card-text ss-input-icon"></i>
                   <input
@@ -877,7 +877,11 @@
           -->
         </div>
       </div>
-    </main>    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    </main>
+    <footer style="text-align: center; margin: 1rem 0;">
+      <small>&copy; 2024 Seguros Sayazu</small>
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../js/config.js"></script>
     <script src="../js/clientes.js"></script>
     <script src="../js/common.js"></script>

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -9,9 +9,11 @@
   </head>
   <body class="ss-login-page">
     <div class="ss-login-container">
-      <div class="ss-login-logo">
-        <img src="../images/logo-color-ss.png" alt="Seguros Sayazu" />
-      </div>
+      <header class="ss-login-logo">
+        <img src="../images/logo-color-ss.png" alt="Logotipo de Seguros Sayazu" />
+      </header>
+
+      <main>
 
       <!-- Login Form -->
       <div id="login-form" class="ss-login-form">
@@ -19,6 +21,7 @@
         <form onsubmit="handleLogin(event)">
           <div class="ss-login-input-group">
             <i class="bi bi-envelope ss-login-input-icon"></i>
+            <label for="correo" class="visually-hidden">Correo electrónico</label>
             <input
               type="email"
               id="correo"
@@ -31,6 +34,7 @@
 
           <div class="ss-login-input-group">
             <i class="bi bi-lock ss-login-input-icon"></i>
+            <label for="contrasena" class="visually-hidden">Contraseña</label>
             <input
               type="password"
               id="contrasena"
@@ -67,10 +71,11 @@
 
       <!-- Register Form -->
       <div id="register-form" class="ss-register-form">
-        <h1 class="ss-login-title">Crear Cuenta</h1>
+        <h2 class="ss-login-title">Crear Cuenta</h2>
         <form onsubmit="handleRegister(event)">
           <div class="ss-login-input-group">
             <i class="bi bi-envelope ss-login-input-icon"></i>
+            <label for="new-correo" class="visually-hidden">Correo electrónico</label>
             <input
               type="email"
               id="new-correo"
@@ -83,6 +88,7 @@
 
           <div class="ss-login-input-group">
             <i class="bi bi-lock ss-login-input-icon"></i>
+            <label for="new-contrasena" class="visually-hidden">Contraseña</label>
             <input
               type="password"
               id="new-contrasena"
@@ -95,6 +101,7 @@
 
           <div class="ss-login-input-group">
             <i class="bi bi-lock-fill ss-login-input-icon"></i>
+            <label for="conf-contrasena" class="visually-hidden">Confirmar contraseña</label>
             <input
               type="password"
               id="conf-contrasena"
@@ -126,6 +133,10 @@
           Volver al inicio de sesión
         </button>
       </div>
+      </main>
+      <footer style="text-align: center; margin-top: 1rem;">
+        <small>&copy; 2024 Seguros Sayazu</small>
+      </footer>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../js/config.js"></script>

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -1,40 +1,40 @@
 const insuranceData = {
   Zurich: {
-    "VehÌculos": ["Seguro Planeta", "Tailor Made"],
+    "Veh√≠culos": ["Seguro Planeta", "Tailor Made"],
     "Responsabilidad Civil": ["Responsabilidad Civil para Empresas"],
     "Seguro Hogar": ["Hogar Total", "Hogar Protegido", "Seguro por Dentro"],
     "Incendio y Desastres Naturales": [],
   },
   Latina: {
-    "VehÌculos": ["B·sicos", "Premium"],
+    "Veh√≠culos": ["B√°sicos", "Premium"],
     Desgravamen: [],
   },
   AMA: {
     "Responsabilidad Civil": ["RC", "Profesional Individual", "Sociedades"],
-    "VehÌculos": ["B·sicos", "Premium"],
+    "Veh√≠culos": ["B√°sicos", "Premium"],
   },
   Sweden: {
-    "VehÌculos": ["VehÌculo", "Motocicleta"],
+    "Veh√≠culos": ["Veh√≠culo", "Motocicleta"],
     Viaje: ["Hogar Seguro Sylver"],
   },
   MAFRE: {
-    "VehÌculos": [],
+    "Veh√≠culos": [],
     "Responsabilidad Civil": [],
     Desgravamen: [],
-    "Incendio y LÌneas Aliadas": [],
+    "Incendio y L√≠neas Aliadas": [],
   },
   Equinoccial: {
     Vida: [],
   },
   Hispana: {
-    "VehÌculos": [],
+    "Veh√≠culos": [],
   },
   BMI: {
     "Medicina Prepagada": ["Individual", "Corporativo"],
     Ahorro: [],
     Vida: [],
     Dental: [],
-    "Cobertura por C·ncer": [],
+    "Cobertura por C√°ncer": [],
   },
   Cofiamed: {
     "Medicina Prepagada": [],
@@ -87,16 +87,16 @@ function updateProducts(insuranceType) {
 
 function validateCI(ci) {
   if (!isNumeric(ci)) {
-    return "La cÈdula debe contener solo n˙meros.";
+    return "La c√©dula debe contener solo n√∫meros.";
   }
   if (ci.length !== 10) {
-    return "La cÈdula debe ser de 10 dÌgitos.";
+    return "La c√©dula debe ser de 10 d√≠gitos.";
   }
   if (parseInt(ci, 10) === 0) {
-    return "La cÈdula ingresada no puede ser cero.";
+    return "La c√©dula ingresada no puede ser cero.";
   }
   if (ci.startsWith("30")) {
-    return "La cÈdula es v·lida.";
+    return "La c√©dula es v√°lida.";
   }
 
   let total = 0;
@@ -115,9 +115,9 @@ function validateCI(ci) {
   let checksum = total % 10 === 0 ? 0 : 10 - (total % 10);
 
   if (checksum === lastDigit) {
-    return "La cÈdula es v·lida.";
+    return "La c√©dula es v√°lida.";
   } else {
-    return "La cÈdula ingresada no es v·lida.";
+    return "La c√©dula ingresada no es v√°lida.";
   }
 }
 
@@ -127,7 +127,7 @@ function isNumeric(value) {
 
 function validateRUC(ruc) {
   if (ruc.length !== 13) {
-    return "El RUC debe ser de 13 dÌgitos.";
+    return "El RUC debe ser de 13 d√≠gitos.";
   }
   if (!ruc.endsWith("001")) {
     return "El RUC debe terminar en '001'.";
@@ -136,19 +136,19 @@ function validateRUC(ruc) {
   let ci = ruc.substring(0, 10);
   let ciValidation = validateCI(ci);
 
-  if (ciValidation === "La cÈdula es v·lida.") {
-    return "El RUC es v·lido.";
+  if (ciValidation === "La c√©dula es v√°lida.") {
+    return "El RUC es v√°lido.";
   } else {
-    return "El RUC ingresado no es v·lido.";
+    return "El RUC ingresado no es v√°lido.";
   }
 }
 
 function validateEmail(email) {
   const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (re.test(email)) {
-    return "El correo electrÛnico es v·lido.";
+    return "El correo electr√≥nico es v√°lido.";
   } else {
-    return "El correo electrÛnico no es v·lido.";
+    return "El correo electr√≥nico no es v√°lido.";
   }
 }
 
@@ -166,14 +166,17 @@ document.addEventListener("DOMContentLoaded", function () {
       validationMessage = validateRUC(value);
     } else {
       validationMessage =
-        "El documento debe ser de 10 dÌgitos (cÈdula) o 13 dÌgitos (RUC).";
+        "El documento debe ser de 10 d√≠gitos (c√©dula) o 13 d√≠gitos (RUC).";
     }
 
     const validationMessageElement = document.getElementById("documentoidentidad-validation");
     validationMessageElement.textContent = validationMessage;
-    validationMessageElement.style.color = validationMessage.includes("v·lida")
-      ? "green"
-      : "red";
+    validationMessageElement.classList.remove("success", "error");
+    if (validationMessage.includes("v√°lida")) {
+      validationMessageElement.classList.add("success");
+    } else {
+      validationMessageElement.classList.add("error");
+    }
   });
 
   correoInput.addEventListener("blur", function () {
@@ -182,8 +185,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const validationMessageElement = document.getElementById("correo-validation");
     validationMessageElement.textContent = validationMessage;
-    validationMessageElement.style.color = validationMessage.includes("v·lido")
-      ? "green"
-      : "red";
+    validationMessageElement.classList.remove("success", "error");
+    if (validationMessage.includes("v√°lido")) {
+      validationMessageElement.classList.add("success");
+    } else {
+      validationMessageElement.classList.add("error");
+    }
   });
 });


### PR DESCRIPTION
## Summary
- adjust color palette to improve contrast
- add visually hidden class and validation message styles
- update login page with semantic regions and labels
- improve clients page with aria labels, footer, and labels
- show validation feedback using CSS classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684892598ac88330b91fe7ed1f631db4